### PR TITLE
feat: implement Gmail SMTP integration for email delivery

### DIFF
--- a/apps/api/peakops/settings.py
+++ b/apps/api/peakops/settings.py
@@ -317,6 +317,6 @@ else:
 # Email timeout settings
 EMAIL_TIMEOUT = config('EMAIL_TIMEOUT', default=30, cast=int)
 
-# For development/testing, use console backend
-if DEBUG:
+# For development/testing, use console backend unless explicitly overridden
+if DEBUG and not config('EMAIL_BACKEND', default=None):
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/apps/marketing/src/pages/DemoPage.tsx
+++ b/apps/marketing/src/pages/DemoPage.tsx
@@ -31,20 +31,17 @@ export default function DemoPage() {
       // Show success message
       setIsSubmitted(true);
       
-      // Reset form after delay
-      setTimeout(() => {
-        setFormData({
-          firstName: '',
-          lastName: '',
-          email: '',
-          company: '',
-          phone: '',
-          stores: '',
-          role: '',
-          message: ''
-        });
-        setIsSubmitted(false);
-      }, 3000);
+      // Clear form immediately
+      setFormData({
+        firstName: '',
+        lastName: '',
+        email: '',
+        company: '',
+        phone: '',
+        stores: '',
+        role: '',
+        message: ''
+      });
       
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to send demo request. Please try again.');


### PR DESCRIPTION
- Configure Django settings to support Gmail SMTP alongside AWS SES
- Modify debug email backend logic to respect EMAIL_BACKEND env var
- Update demo form to clear immediately and show success message indefinitely
- Enable USE_SES=False to bypass SES and use SMTP configuration
- Set consistent domain (getpeakops.com) for authentication and from address

This allows temporary use of Gmail SMTP for development and production email delivery while maintaining the option to switch back to AWS SES.

🤖 Generated with [Claude Code](https://claude.ai/code)